### PR TITLE
fix unordered numeric array comparison

### DIFF
--- a/lib/OpenPayU/Util.php
+++ b/lib/OpenPayU/Util.php
@@ -312,7 +312,9 @@ class OpenPayU_Util
      */
     public static function isAssocArray($arr)
     {
-        return array_keys($arr) !== range(0, count($arr) - 1);
+        $arrKeys = array_keys($arr);
+        sort($arrKeys, SORT_NUMERIC);
+        return $arrKeys !== range(0, count($arr) - 1);
     }
 
     /**


### PR DESCRIPTION
If I would have array such as [1 => 'a', 0 => 'b', 2 => 'c'] current function version would return true which is not true :-)

Sorting keys first solves problem.
