### PR TITLE
[composer] Only require phpunit while development

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "php": ">=5.2.1",
         "ext-curl": "*",
         "ext-hash": "*"
+    },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"
     },


### PR DESCRIPTION
This is not a required library for production
