### PR TITLE
[composer] Use GIT tags instead hardcode version number

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "type": "library",
     "license": "LGPL-3.0",
     "description": "OpenPayU PHP Library",
-    "version": "2.0.4",
     "extra": [
         {
             "engine": "PHP SDK"


### PR DESCRIPTION
Instead of hardcode the version of any new release it's better tag the commit with a version number.

By this way packagist.org can autodiscover versions and it's more easy manage the versioning for your team.
