### PR TITLE
Remove persistentId ("PayU") from OauthCacheMemcached

### DIFF
--- a/lib/OpenPayU/Oauth/Cache/OauthCacheMemcached.php
+++ b/lib/OpenPayU/Oauth/Cache/OauthCacheMemcached.php
@@ -16,7 +16,7 @@ class OauthCacheMemcached implements OauthCacheInterface
             throw new OpenPayU_Exception_Configuration('PHP Memcached extension not installed.');
         }
 
-        $this->memcached = new Memcached('PayU');
+        $this->memcached = new Memcached();
         $this->memcached->addServer($host, $port, $weight);
         $stats = $this->memcached->getStats();
         if ($stats[$host . ':' . $port]['pid'] == -1) {


### PR DESCRIPTION
It's not namespace or prefix - it's persistent_id.

http://php.net/manual/en/memcached.construct.php

persistent_id
By default the Memcached instances are destroyed at the end of the request. To create an instance that persists between requests, use persistent_id to specify a unique ID for the instance. All instances created with the same persistent_id will share the same connection.

If it's in constructor - the number of current connections to memcached grows rapidly.

