### PR TITLE
Handle network exceptions separately in Oauth

### DIFF
--- a/lib/OpenPayU/AuthType/Oauth.php
+++ b/lib/OpenPayU/AuthType/Oauth.php
@@ -20,6 +20,8 @@ class AuthType_Oauth implements AuthType
 
         try {
             $this->oauthResult = OpenPayU_Oauth::getAccessToken();
+        } catch (OpenPayU_Exception_Network $e) {
+            throw $e;
         } catch (OpenPayU_Exception $e) {
             throw new OpenPayU_Exception('Oauth error: [code=' . $e->getCode() . '], [message=' . $e->getMessage() . ']');
         }


### PR DESCRIPTION
Hi, 

I am currently experiencing timeout issues with cURL when trying to get an Oauth token from the Payu entry point. 

Unfortunately, I cannot handle these errors and retry the connection as I would like because of this exception handling here, 

https://github.com/PayU-EMEA/openpayu_php/blob/181d7aaa4a2b97d7c0cefd04ce49b853a959fd78/lib/OpenPayU/HttpCurl.php#L60

As of below a standard Oauth error message is thrown with `Oauth error` etc.

This isn't useful for the external calling code as we cannot determine what is a network error (which we could be retrying) and what is a business error (which we should leave alone).

This changes that so we separate the Network exception from the rest of the crowd so any calling code can then do the required steps on their end to handle for this.