### PR TITLE
Add PHP 7 to TravisCI checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: php
 php:
-  - 5.5
-  - 5.4
-  - 5.3
-  - 5.2
+  - 7.4
+  - 7.3
+  - 7.2
+  - 7.1
+  - 7.0
+  - 5.6
+
+before_script:
+  - composer install
+
+script:
+  - vendor/bin/phpunit tests

--- a/tests/unit/OpenPayU_ConfigurationTest.php
+++ b/tests/unit/OpenPayU_ConfigurationTest.php
@@ -9,8 +9,6 @@
  */
 
 require_once realpath(dirname(__FILE__)) . '/../TestHelper.php';
-require realpath(dirname(__FILE__)) . '\..\..\vendor/autoload.php';
-
 
 class OpenPayU_ConfigurationTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/unit/OpenPayU_UtilTest.php
+++ b/tests/unit/OpenPayU_UtilTest.php
@@ -70,7 +70,7 @@ class OpenPayU_UtilTest extends PHPUnit_Framework_TestCase
             array('TEST', null),
             array(
                 'sender=MerchantPosId;algorithm=SHA-256;signature=e4c8315c9ab2e097ef1221f3fbd1e761405d961760e538fb2e0055d3d90b5e35',
-                (object) array('sender' => 'MerchantPosId', 'algorithm' => 'SHA-256', 'signature' => 'e4c8315c9ab2e097ef1221f3fbd1e761405d961760e538fb2e0055d3d90b5e35')
+                array('sender' => 'MerchantPosId', 'algorithm' => 'SHA-256', 'signature' => 'e4c8315c9ab2e097ef1221f3fbd1e761405d961760e538fb2e0055d3d90b5e35')
             )
         );
     }


### PR DESCRIPTION
Remove old unsupported PHP versions, add PHP 7 to TravisCI checks, update unit tests.

All tests are green: https://travis-ci.org/github/vojtasvoboda/openpayu_php/builds/770708182

<img width="1018" alt="Screenshot 2021-05-11 v 13 34 48" src="https://user-images.githubusercontent.com/374917/117808835-aed79a00-b25d-11eb-99d8-19f3269fef19.png">
