### PR TITLE
Don't call curl_close on PHP 8.0 or higher, it doesn't do anything an…

### DIFF
--- a/lib/OpenPayU/HttpCurl.php
+++ b/lib/OpenPayU/HttpCurl.php
@@ -61,7 +61,10 @@ class OpenPayU_HttpCurl
         if($response === false) {
             throw new OpenPayU_Exception_Network(curl_error($ch));
         }
-        curl_close($ch);
+
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        }
 
         return array('code' => $httpStatus, 'response' => trim($response));
     }


### PR DESCRIPTION
…d got deprecated in PHP 8.5


See the documentation: https://www.php.net/manual/en/function.curl-close.php

> Note: This function has no effect. Prior to PHP 8.0.0, this function was used to close the resource.

> This function has been DEPRECATED as of PHP 8.5.0. Relying on this function is highly discouraged.


This module declares itself as needing PHP 7.4 or higher. So we can't fully remove this function call, hence it's now wrapped in a check to see which PHP version is running the code to only execute on PHP < 8.0. So we get no deprecated warning when running this code on PHP 8.5 or higher.